### PR TITLE
ATC - Challenge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # BUILD FOR LOCAL DEVELOPMENT
 ###################
 
-FROM node:16.17-alpine As development
+FROM node:16.17.0-alpine As development
 
 WORKDIR /usr/src/app
 
@@ -18,7 +18,7 @@ USER node
 # BUILD FOR PRODUCTION
 ###################
 
-FROM node:16.7-alpine As build
+FROM node:16.17.0-alpine As build
 
 WORKDIR /usr/src/app
 
@@ -44,7 +44,7 @@ USER node
 # PRODUCTION
 ###################
 
-FROM node:16.7-alpine As production
+FROM node:16.17.0-alpine As production
 
 COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - .:/usr/src/app
     command: npm run start:dev
     ports:
-      - 3000:3000
+      - 3001:3000
     environment:
       ATC_BASE_URL: http://mock:4000
   mock:

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
   },
   "dependencies": {
     "@nestjs/axios": "0.1.0",
+    "@nestjs/cache-manager": "2.0.0",
     "@nestjs/common": "9.0.0",
     "@nestjs/config": "2.2.0",
     "@nestjs/core": "9.0.0",
     "@nestjs/cqrs": "9.0.1",
     "@nestjs/platform-fastify": "9.0.11",
+    "cache-manager": "5.4.0",
     "moment": "2.29.4",
     "nestjs-zod": "1.2.1",
     "reflect-metadata": "0.1.13",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,5 @@
 import { HttpModule } from '@nestjs/axios';
+import { CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { CqrsModule } from '@nestjs/cqrs';
@@ -11,7 +12,12 @@ import { EventsController } from './infrastructure/controllers/events.controller
 import { SearchController } from './infrastructure/controllers/search.controller';
 
 @Module({
-  imports: [HttpModule, CqrsModule, ConfigModule.forRoot()],
+  imports: [
+    HttpModule,
+    CqrsModule,
+    ConfigModule.forRoot(),
+    CacheModule.register({ isGlobal: true }),
+  ],
   controllers: [SearchController, EventsController],
   providers: [
     {

--- a/src/domain/handlers/get-availability.handler.spec.ts
+++ b/src/domain/handlers/get-availability.handler.spec.ts
@@ -1,6 +1,6 @@
 import * as moment from 'moment';
 
-import { AlquilaTuCanchaClient } from '../../domain/ports/aquila-tu-cancha.client';
+import { AlquilaTuCanchaClient } from '../ports/aquila-tu-cancha.client';
 import { GetAvailabilityQuery } from '../commands/get-availaiblity.query';
 import { Club } from '../model/club';
 import { Court } from '../model/court';

--- a/src/domain/handlers/get-availability.handler.ts
+++ b/src/domain/handlers/get-availability.handler.ts
@@ -20,27 +20,34 @@ export class GetAvailabilityHandler
   ) {}
 
   async execute(query: GetAvailabilityQuery): Promise<ClubWithAvailability[]> {
-    const clubs_with_availability: ClubWithAvailability[] = [];
     const clubs = await this.alquilaTuCanchaClient.getClubs(query.placeId);
-    for (const club of clubs) {
-      const courts = await this.alquilaTuCanchaClient.getCourts(club.id);
-      const courts_with_availability: ClubWithAvailability['courts'] = [];
-      for (const court of courts) {
-        const slots = await this.alquilaTuCanchaClient.getAvailableSlots(
-          club.id,
-          court.id,
-          query.date,
+
+    const clubs_with_availability: ClubWithAvailability[] = await Promise.all(
+      clubs.map(async (club) => {
+        const courts = await this.alquilaTuCanchaClient.getCourts(club.id);
+
+        const courts_with_availability = await Promise.all(
+          courts.map(async (court) => {
+            const slots = await this.alquilaTuCanchaClient.getAvailableSlots(
+              club.id,
+              court.id,
+              query.date,
+            );
+
+            return {
+              ...court,
+              available: slots,
+            };
+          }),
         );
-        courts_with_availability.push({
-          ...court,
-          available: slots,
-        });
-      }
-      clubs_with_availability.push({
-        ...club,
-        courts: courts_with_availability,
-      });
-    }
+
+        return {
+          ...club,
+          courts: courts_with_availability,
+        };
+      }),
+    );
+
     return clubs_with_availability;
   }
 }

--- a/src/infrastructure/clients/http-alquila-tu-cancha.client.ts
+++ b/src/infrastructure/clients/http-alquila-tu-cancha.client.ts
@@ -1,6 +1,8 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Cache } from 'cache-manager';
 import * as moment from 'moment';
 
 import { Club } from '../../domain/model/club';
@@ -11,37 +13,82 @@ import { AlquilaTuCanchaClient } from '../../domain/ports/aquila-tu-cancha.clien
 @Injectable()
 export class HTTPAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
   private base_url: string;
-  constructor(private httpService: HttpService, config: ConfigService) {
+  private readonly logger = new Logger(HTTPAlquilaTuCanchaClient.name);
+
+  constructor(
+    private httpService: HttpService,
+    config: ConfigService,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
+  ) {
     this.base_url = config.get<string>('ATC_BASE_URL', 'http://localhost:4000');
   }
 
   async getClubs(placeId: string): Promise<Club[]> {
-    return this.httpService.axiosRef
+    const key = `placeId-${placeId}-clubs`;
+
+    try {
+      const cache_clubs = await this.cacheManager.get<Club[]>(key);
+      if (cache_clubs) return cache_clubs;
+    } catch (error) {
+      this.logger.log('Failer cache: getClubs');
+    }
+
+    const clubs: Club[] = await this.httpService.axiosRef
       .get('clubs', {
         baseURL: this.base_url,
         params: { placeId },
       })
       .then((res) => res.data);
+
+    await this.cacheManager.set(key, clubs, 1000 * 60 * 60);
+
+    return clubs;
   }
 
-  getCourts(clubId: number): Promise<Court[]> {
-    return this.httpService.axiosRef
+  async getCourts(clubId: number): Promise<Court[]> {
+    const key = `clubId-${clubId}-courts`;
+
+    try {
+      const cache_courts = await this.cacheManager.get<Court[]>(key);
+      if (cache_courts) return cache_courts;
+    } catch (error) {
+      this.logger.log('Failer cache: getCourts');
+    }
+
+    const courts: Court[] = await this.httpService.axiosRef
       .get(`/clubs/${clubId}/courts`, {
         baseURL: this.base_url,
       })
       .then((res) => res.data);
+
+    await this.cacheManager.set(key, courts, 1000 * 60 * 60);
+
+    return courts;
   }
 
-  getAvailableSlots(
+  async getAvailableSlots(
     clubId: number,
     courtId: number,
     date: Date,
   ): Promise<Slot[]> {
-    return this.httpService.axiosRef
+    const key = `clubId-${clubId}-courts-${courtId}-date-${date}-slots`;
+
+    try {
+      const cache_slots = await this.cacheManager.get<Slot[]>(key);
+      if (cache_slots) return cache_slots;
+    } catch (error) {
+      this.logger.log('Failer cache: getAvailableSlots');
+    }
+
+    const availableSlots: Slot[] = await this.httpService.axiosRef
       .get(`/clubs/${clubId}/courts/${courtId}/slots`, {
         baseURL: this.base_url,
         params: { date: moment(date).format('YYYY-MM-DD') },
       })
       .then((res) => res.data);
+
+    await this.cacheManager.set(key, availableSlots, 1000 * 60 * 60);
+
+    return availableSlots;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,6 +672,11 @@
   dependencies:
     axios "0.27.2"
 
+"@nestjs/cache-manager@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/cache-manager/-/cache-manager-2.0.0.tgz#fb0d212507802924841d16b0a201d4aa86037bdf"
+  integrity sha512-DSBAPQhgG7mRZZSqzqFXoZKtrT/ehlcEvXBpYVd6i42XdM0fLdmp8+6usev12POOkZTLMxRiW87J8U9cGjaExg==
+
 "@nestjs/cli@9.0.0":
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/@nestjs/cli/-/cli-9.0.0.tgz#f9ab4c33cfbc9ee54d792fe29e0f582e0bf04b06"
@@ -1513,6 +1518,15 @@ buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
+
+cache-manager@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/cache-manager/-/cache-manager-5.4.0.tgz#cec47dbea8e49e0f6970d117be10172b4e621358"
+  integrity sha512-FS7o8vqJosnLpu9rh2gQTo8EOzCRJLF1BJ4XDEUDMqcfvs7SJZs5iuoFTXLauzQ3S5v8sBAST1pCwMaurpyi1A==
+  dependencies:
+    lodash.clonedeep "^4.5.0"
+    lru-cache "^10.1.0"
+    promise-coalesce "^1.1.2"
 
 call-bind@^1.0.0:
   version "1.0.2"
@@ -3256,6 +3270,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -3278,6 +3297,11 @@ log-symbols@^4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
+
+lru-cache@^10.1.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -3719,6 +3743,11 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-coalesce@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/promise-coalesce/-/promise-coalesce-1.1.2.tgz#5d3bc4d0b2cf2e41e9df7cbeb6519b2a09459e3d"
+  integrity sha512-zLaJ9b8hnC564fnJH6NFSOGZYYdzrAJn2JUUIwzoQb32fG2QAakpDNM+CZo1km6keXkRXRM+hml1BFAPVnPkxg==
 
 prompts@^2.0.1:
   version "2.4.2"


### PR DESCRIPTION
_ En el archivo get-availability.handler.ts

Se implementó la estrategia de peticiones paralelas con Promise.all para optimizar la ejecución de llamadas asíncronas que antes estaban dentro del bucle FOR.

_ En el archivo http-alquila-tu-cancha.client.ts

Se aplicó una estrategia de caching para responder más rápido a peticiones repetidas o similares de los clientes.
Para la implementación se utilizó la documentación oficial de Nest: [https://docs.nestjs.com/techniques/caching](https://docs.nestjs.com/techniques/caching?utm_source=chatgpt.com).

_ En el archivo events.controller.ts

Se agregó la estrategia de invalidar el cache cuando llegan eventos de actualización.

Gracias a estos cambios, la performance mejoró bastante: la primera petición ahora tarda alrededor de 5 segundos, pero una vez cacheada la información, las respuestas bajan a menos de 10ms. En los casos donde se invalida el cache, las respuestas llegan a tardar aproximadamente 1 segundo.