### PR TITLE
Optimización de /search con Redis + Event-Driven Invalidation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # BUILD FOR LOCAL DEVELOPMENT
 ###################
 
-FROM node:16.17-alpine As development
+FROM node:16.17.0-alpine As development
 
 WORKDIR /usr/src/app
 
@@ -18,7 +18,7 @@ USER node
 # BUILD FOR PRODUCTION
 ###################
 
-FROM node:16.7-alpine As build
+FROM node:16.17.0-alpine As build
 
 WORKDIR /usr/src/app
 
@@ -44,7 +44,7 @@ USER node
 # PRODUCTION
 ###################
 
-FROM node:16.7-alpine As production
+FROM node:16.17.0-alpine As production
 
 COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /usr/src/app/dist ./dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       - 3000:3000
     environment:
       ATC_BASE_URL: http://mock:4000
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    depends_on:
+      redis:
+        condition: service_healthy
   mock:
     image: atc-challenge:dev
     command: node /usr/src/app/mock/server.js
@@ -24,3 +29,12 @@ services:
       EVENT_INTERVAL_SECONDS: 10
       REQUESTS_PER_MINUTE: 60
       EVENT_PUBLISHER_URL: http://api:3000/events
+  redis:
+    image: redis:7-alpine
+    ports:
+      - 6379:6379
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/core": "9.0.0",
     "@nestjs/cqrs": "9.0.1",
     "@nestjs/platform-fastify": "9.0.11",
+    "ioredis": "^5.3.2",
     "moment": "2.29.4",
     "nestjs-zod": "1.2.1",
     "reflect-metadata": "0.1.13",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,8 +4,13 @@ import { ConfigModule } from '@nestjs/config';
 import { CqrsModule } from '@nestjs/cqrs';
 
 import { ClubUpdatedHandler } from './domain/handlers/club-updated.handler';
+import { CourtUpdatedHandler } from './domain/handlers/court-updated.handler';
 import { GetAvailabilityHandler } from './domain/handlers/get-availability.handler';
+import { SlotAvailableHandler } from './domain/handlers/slot-available.handler';
+import { SlotBookedHandler } from './domain/handlers/slot-booked.handler';
 import { ALQUILA_TU_CANCHA_CLIENT } from './domain/ports/aquila-tu-cancha.client';
+import { RedisCacheService } from './infrastructure/cache/redis-cache.service';
+import { CachedAlquilaTuCanchaClient } from './infrastructure/clients/cached-alquila-tu-cancha.client';
 import { HTTPAlquilaTuCanchaClient } from './infrastructure/clients/http-alquila-tu-cancha.client';
 import { EventsController } from './infrastructure/controllers/events.controller';
 import { SearchController } from './infrastructure/controllers/search.controller';
@@ -14,12 +19,17 @@ import { SearchController } from './infrastructure/controllers/search.controller
   imports: [HttpModule, CqrsModule, ConfigModule.forRoot()],
   controllers: [SearchController, EventsController],
   providers: [
+    RedisCacheService,
+    HTTPAlquilaTuCanchaClient,
     {
       provide: ALQUILA_TU_CANCHA_CLIENT,
-      useClass: HTTPAlquilaTuCanchaClient,
+      useClass: CachedAlquilaTuCanchaClient,
     },
     GetAvailabilityHandler,
     ClubUpdatedHandler,
+    CourtUpdatedHandler,
+    SlotBookedHandler,
+    SlotAvailableHandler,
   ],
 })
 export class AppModule {}

--- a/src/domain/handlers/club-updated.handler.ts
+++ b/src/domain/handlers/club-updated.handler.ts
@@ -1,13 +1,53 @@
 import { Logger } from '@nestjs/common';
 import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
 
+import { RedisCacheService } from '../../infrastructure/cache/redis-cache.service';
+import { CacheKeys } from '../../infrastructure/cache/cache-keys';
 import { ClubUpdatedEvent } from '../events/club-updated.event';
 
 @EventsHandler(ClubUpdatedEvent)
 export class ClubUpdatedHandler implements IEventHandler<ClubUpdatedEvent> {
   private readonly logger = new Logger(ClubUpdatedHandler.name);
 
-  handle(event: ClubUpdatedEvent) {
-    this.logger.log(`Club ${event.clubId} updated`);
+  constructor(private cache: RedisCacheService) {}
+
+  async handle(event: ClubUpdatedEvent) {
+    const { clubId, fields } = event;
+
+    this.logger.log(`Club ${clubId} updated - Fields: ${fields.join(', ')}`);
+
+    const affectsAvailability = fields.includes('openhours');
+    const placeId = await this.cache.get<string>(CacheKeys.clubToPlace(clubId));
+
+    if (placeId) {
+      const clubsKey = CacheKeys.clubs(placeId);
+      await this.cache.del(clubsKey);
+    }
+
+    const courtsKey = CacheKeys.courts(clubId);
+    await this.cache.del(courtsKey);
+
+    if (affectsAvailability) {
+      const slotsPattern = `slots:${clubId}:*`;
+      await this.cache.delPattern(slotsPattern);
+
+      if (placeId) {
+        for (let i = 0; i < 7; i++) {
+          const date = new Date();
+          date.setDate(date.getDate() + i);
+          const searchKey = CacheKeys.search(placeId, date);
+          await this.cache.del(searchKey);
+        }
+      }
+    } else {
+      if (placeId) {
+        for (let i = 0; i < 7; i++) {
+          const date = new Date();
+          date.setDate(date.getDate() + i);
+          const searchKey = CacheKeys.search(placeId, date);
+          await this.cache.del(searchKey);
+        }
+      }
+    }
   }
 }

--- a/src/domain/handlers/court-updated.handler.ts
+++ b/src/domain/handlers/court-updated.handler.ts
@@ -1,0 +1,36 @@
+import { Logger } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+
+import { RedisCacheService } from '../../infrastructure/cache/redis-cache.service';
+import { CacheKeys } from '../../infrastructure/cache/cache-keys';
+import { CourtUpdatedEvent } from '../events/court-updated.event';
+
+@EventsHandler(CourtUpdatedEvent)
+export class CourtUpdatedHandler implements IEventHandler<CourtUpdatedEvent> {
+  private readonly logger = new Logger(CourtUpdatedHandler.name);
+
+  constructor(private cache: RedisCacheService) {}
+
+  async handle(event: CourtUpdatedEvent) {
+    const { clubId, courtId, fields } = event;
+
+    this.logger.log(
+      `Court updated - Club ${clubId}, Court ${courtId}, Fields: ${fields.join(
+        ', ',
+      )}`,
+    );
+
+    const courtsKey = CacheKeys.courts(clubId);
+    await this.cache.del(courtsKey);
+
+    const placeId = await this.cache.get<string>(CacheKeys.clubToPlace(clubId));
+    if (placeId) {
+      for (let i = 0; i < 7; i++) {
+        const date = new Date();
+        date.setDate(date.getDate() + i);
+        const searchKey = CacheKeys.search(placeId, date);
+        await this.cache.del(searchKey);
+      }
+    }
+  }
+}

--- a/src/domain/handlers/get-availability.handler.ts
+++ b/src/domain/handlers/get-availability.handler.ts
@@ -5,42 +5,79 @@ import {
   ClubWithAvailability,
   GetAvailabilityQuery,
 } from '../commands/get-availaiblity.query';
+import { Court } from '../model/court';
 import {
   ALQUILA_TU_CANCHA_CLIENT,
   AlquilaTuCanchaClient,
 } from '../ports/aquila-tu-cancha.client';
 
+async function pMap<T, R>(
+  items: T[],
+  mapper: (item: T) => Promise<R>,
+  concurrency: number,
+): Promise<R[]> {
+  const results: R[] = [];
+
+  for (let i = 0; i < items.length; i += concurrency) {
+    const batch = items.slice(i, i + concurrency);
+    const batchResults = await Promise.all(batch.map(mapper));
+    results.push(...batchResults);
+  }
+
+  return results;
+}
+
 @QueryHandler(GetAvailabilityQuery)
 export class GetAvailabilityHandler
   implements IQueryHandler<GetAvailabilityQuery>
 {
+  private readonly CONCURRENCY_LIMIT = 10;
+
   constructor(
     @Inject(ALQUILA_TU_CANCHA_CLIENT)
     private alquilaTuCanchaClient: AlquilaTuCanchaClient,
   ) {}
 
   async execute(query: GetAvailabilityQuery): Promise<ClubWithAvailability[]> {
-    const clubs_with_availability: ClubWithAvailability[] = [];
     const clubs = await this.alquilaTuCanchaClient.getClubs(query.placeId);
-    for (const club of clubs) {
-      const courts = await this.alquilaTuCanchaClient.getCourts(club.id);
-      const courts_with_availability: ClubWithAvailability['courts'] = [];
-      for (const court of courts) {
-        const slots = await this.alquilaTuCanchaClient.getAvailableSlots(
-          club.id,
-          court.id,
-          query.date,
+
+    const clubsWithCourts = await pMap(
+      clubs,
+      async (club) => {
+        const courts = await this.alquilaTuCanchaClient.getCourts(club.id);
+        return { club, courts };
+      },
+      this.CONCURRENCY_LIMIT,
+    );
+
+    const clubsWithAvailability: ClubWithAvailability[] = await pMap(
+      clubsWithCourts,
+      async ({ club, courts }) => {
+        const courtsWithAvailability = await pMap(
+          courts,
+          async (court: Court) => {
+            const slots = await this.alquilaTuCanchaClient.getAvailableSlots(
+              club.id,
+              court.id,
+              query.date,
+            );
+
+            return {
+              ...court,
+              available: slots,
+            };
+          },
+          this.CONCURRENCY_LIMIT,
         );
-        courts_with_availability.push({
-          ...court,
-          available: slots,
-        });
-      }
-      clubs_with_availability.push({
-        ...club,
-        courts: courts_with_availability,
-      });
-    }
-    return clubs_with_availability;
+
+        return {
+          ...club,
+          courts: courtsWithAvailability,
+        };
+      },
+      this.CONCURRENCY_LIMIT,
+    );
+
+    return clubsWithAvailability;
   }
 }

--- a/src/domain/handlers/slot-available.handler.ts
+++ b/src/domain/handlers/slot-available.handler.ts
@@ -1,0 +1,34 @@
+import { Logger } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import * as moment from 'moment';
+
+import { RedisCacheService } from '../../infrastructure/cache/redis-cache.service';
+import { CacheKeys } from '../../infrastructure/cache/cache-keys';
+import { SlotAvailableEvent } from '../events/slot-cancelled.event';
+
+@EventsHandler(SlotAvailableEvent)
+export class SlotAvailableHandler implements IEventHandler<SlotAvailableEvent> {
+  private readonly logger = new Logger(SlotAvailableHandler.name);
+
+  constructor(private cache: RedisCacheService) {}
+
+  async handle(event: SlotAvailableEvent) {
+    const { clubId, courtId, slot } = event;
+    const date = moment(slot.datetime, 'YYYY-MM-DD HH:mm').toDate();
+
+    this.logger.log(
+      `Slot cancelled - Club ${clubId}, Court ${courtId}, Date ${moment(
+        date,
+      ).format('YYYY-MM-DD')}, Time ${slot.start}`,
+    );
+
+    const slotsKey = CacheKeys.slots(clubId, courtId, date);
+    await this.cache.del(slotsKey);
+
+    const placeId = await this.cache.get<string>(CacheKeys.clubToPlace(clubId));
+    if (placeId) {
+      const searchKey = CacheKeys.search(placeId, date);
+      await this.cache.del(searchKey);
+    }
+  }
+}

--- a/src/domain/handlers/slot-booked.handler.spec.ts
+++ b/src/domain/handlers/slot-booked.handler.spec.ts
@@ -1,0 +1,51 @@
+import { Test } from '@nestjs/testing';
+
+import { RedisCacheService } from '../../infrastructure/cache/redis-cache.service';
+import { SlotBookedEvent } from '../events/slot-booked.event';
+import { SlotBookedHandler } from './slot-booked.handler';
+
+describe('SlotBookedHandler', () => {
+  let handler: SlotBookedHandler;
+  let cache: jest.Mocked<RedisCacheService>;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        SlotBookedHandler,
+        {
+          provide: RedisCacheService,
+          useValue: {
+            get: jest.fn(),
+            del: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = module.get(SlotBookedHandler);
+    cache = module.get(RedisCacheService);
+  });
+
+  it('should invalidate slots cache when slot is booked', async () => {
+    const event = new SlotBookedEvent(166, 733, {
+      price: 4000,
+      duration: 60,
+      datetime: '2022-08-25 09:00',
+      start: '09:00',
+      end: '10:00',
+      _priority: 0,
+    });
+
+    cache.get.mockResolvedValue('ChIJW9fXNZNTtpURV6VYAumGQOw');
+
+    await handler.handle(event);
+
+    // Should delete slots cache for the specific date
+    expect(cache.del).toHaveBeenCalledWith('slots:166:733:2022-08-25');
+
+    // Should delete search cache
+    expect(cache.del).toHaveBeenCalledWith(
+      'search:ChIJW9fXNZNTtpURV6VYAumGQOw:2022-08-25',
+    );
+  });
+});

--- a/src/domain/handlers/slot-booked.handler.spec.ts
+++ b/src/domain/handlers/slot-booked.handler.spec.ts
@@ -40,10 +40,7 @@ describe('SlotBookedHandler', () => {
 
     await handler.handle(event);
 
-    // Should delete slots cache for the specific date
     expect(cache.del).toHaveBeenCalledWith('slots:166:733:2022-08-25');
-
-    // Should delete search cache
     expect(cache.del).toHaveBeenCalledWith(
       'search:ChIJW9fXNZNTtpURV6VYAumGQOw:2022-08-25',
     );

--- a/src/domain/handlers/slot-booked.handler.ts
+++ b/src/domain/handlers/slot-booked.handler.ts
@@ -1,0 +1,34 @@
+import { Logger } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import * as moment from 'moment';
+
+import { RedisCacheService } from '../../infrastructure/cache/redis-cache.service';
+import { CacheKeys } from '../../infrastructure/cache/cache-keys';
+import { SlotBookedEvent } from '../events/slot-booked.event';
+
+@EventsHandler(SlotBookedEvent)
+export class SlotBookedHandler implements IEventHandler<SlotBookedEvent> {
+  private readonly logger = new Logger(SlotBookedHandler.name);
+
+  constructor(private cache: RedisCacheService) {}
+
+  async handle(event: SlotBookedEvent) {
+    const { clubId, courtId, slot } = event;
+    const date = moment(slot.datetime, 'YYYY-MM-DD HH:mm').toDate();
+
+    this.logger.log(
+      `Slot booked - Club ${clubId}, Court ${courtId}, Date ${moment(
+        date,
+      ).format('YYYY-MM-DD')}, Time ${slot.start}`,
+    );
+
+    const slotsKey = CacheKeys.slots(clubId, courtId, date);
+    await this.cache.del(slotsKey);
+
+    const placeId = await this.cache.get<string>(CacheKeys.clubToPlace(clubId));
+    if (placeId) {
+      const searchKey = CacheKeys.search(placeId, date);
+      await this.cache.del(searchKey);
+    }
+  }
+}

--- a/src/infrastructure/cache/cache-keys.ts
+++ b/src/infrastructure/cache/cache-keys.ts
@@ -1,0 +1,21 @@
+import * as moment from 'moment';
+
+export const CacheKeys = {
+  search: (placeId: string, date: Date): string =>
+    `search:${placeId}:${moment(date).format('YYYY-MM-DD')}`,
+  clubs: (placeId: string): string => `clubs:${placeId}`,
+  courts: (clubId: number): string => `courts:${clubId}`,
+  slots: (clubId: number, courtId: number, date: Date): string =>
+    `slots:${clubId}:${courtId}:${moment(date).format('YYYY-MM-DD')}`,
+  clubToPlace: (clubId: number): string => `club->place:${clubId}`,
+  stale: (key: string): string => `${key}:stale`,
+};
+
+export const CacheTTL = {
+  SEARCH_RESULT: 60,
+  CLUBS: 3600,
+  COURTS: 3600,
+  SLOTS: 120,
+  CLUB_TO_PLACE: 86400,
+  STALE: 86400,
+};

--- a/src/infrastructure/cache/redis-cache.service.ts
+++ b/src/infrastructure/cache/redis-cache.service.ts
@@ -1,0 +1,136 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+import { CacheKeys } from './cache-keys';
+
+@Injectable()
+export class RedisCacheService implements OnModuleDestroy {
+  private readonly logger = new Logger(RedisCacheService.name);
+  private redis: Redis;
+
+  constructor(config: ConfigService) {
+    const host = config.get<string>('REDIS_HOST', 'localhost');
+    const port = config.get<number>('REDIS_PORT', 6379);
+
+    this.redis = new Redis({
+      host,
+      port,
+      retryStrategy: (times) => {
+        const delay = Math.min(times * 50, 2000);
+        return delay;
+      },
+      maxRetriesPerRequest: 3,
+      lazyConnect: true,
+    });
+
+    this.redis.connect().catch((err) => {
+      this.logger.error(`Failed to connect to Redis: ${err.message}`);
+    });
+
+    this.redis.on('error', (err) => {
+      this.logger.error(`Redis error: ${err.message}`);
+    });
+
+    this.redis.on('connect', () => {
+      this.logger.log(`Connected to Redis at ${host}:${port}`);
+    });
+  }
+
+  async onModuleDestroy() {
+    await this.redis.quit();
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    try {
+      const value = await this.redis.get(key);
+      if (!value) return null;
+      return JSON.parse(value) as T;
+    } catch (err) {
+      this.logger.warn(`Cache GET error for key ${key}: ${err.message}`);
+      return null;
+    }
+  }
+
+  async getWithStale<T>(key: string): Promise<T | null> {
+    const fresh = await this.get<T>(key);
+    if (fresh !== null) return fresh;
+
+    const staleKey = CacheKeys.stale(key);
+    const stale = await this.get<T>(staleKey);
+
+    if (stale !== null) {
+      this.logger.warn(`Returning stale data for key ${key}`);
+    }
+
+    return stale;
+  }
+
+  async set(key: string, value: any, ttl: number): Promise<void> {
+    try {
+      const serialized = JSON.stringify(value);
+      await this.redis.setex(key, ttl, serialized);
+
+      const staleKey = CacheKeys.stale(key);
+      await this.redis.setex(staleKey, 86400, serialized);
+    } catch (err) {
+      this.logger.error(`Cache SET error for key ${key}: ${err.message}`);
+    }
+  }
+
+  async del(key: string): Promise<void> {
+    try {
+      await this.redis.del(key);
+      const staleKey = CacheKeys.stale(key);
+      await this.redis.del(staleKey);
+    } catch (err) {
+      this.logger.error(`Cache DEL error for key ${key}: ${err.message}`);
+    }
+  }
+
+  async delPattern(pattern: string): Promise<number> {
+    try {
+      let cursor = '0';
+      let deletedCount = 0;
+
+      do {
+        const [newCursor, keys] = await this.redis.scan(
+          cursor,
+          'MATCH',
+          pattern,
+          'COUNT',
+          100,
+        );
+
+        cursor = newCursor;
+
+        if (keys.length > 0) {
+          await this.redis.del(...keys);
+          deletedCount += keys.length;
+
+          const staleKeys = keys.map((k) => CacheKeys.stale(k));
+          await this.redis.del(...staleKeys);
+        }
+      } while (cursor !== '0');
+
+      this.logger.log(
+        `Deleted ${deletedCount} keys matching pattern ${pattern}`,
+      );
+      return deletedCount;
+    } catch (err) {
+      this.logger.error(
+        `Cache DEL_PATTERN error for pattern ${pattern}: ${err.message}`,
+      );
+      return 0;
+    }
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      await this.redis.ping();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/infrastructure/clients/cached-alquila-tu-cancha.client.spec.ts
+++ b/src/infrastructure/clients/cached-alquila-tu-cancha.client.spec.ts
@@ -79,7 +79,6 @@ describe('CachedAlquilaTuCanchaClient', () => {
 
       await client.getClubs(placeId);
 
-      // Should store index for each club
       expect(cache.set).toHaveBeenCalledWith(
         CacheKeys.clubToPlace(1),
         placeId,

--- a/src/infrastructure/clients/cached-alquila-tu-cancha.client.spec.ts
+++ b/src/infrastructure/clients/cached-alquila-tu-cancha.client.spec.ts
@@ -1,0 +1,108 @@
+import { Test } from '@nestjs/testing';
+
+import { Club } from '../../domain/model/club';
+import { CacheKeys, CacheTTL } from '../cache/cache-keys';
+import { RedisCacheService } from '../cache/redis-cache.service';
+import { CachedAlquilaTuCanchaClient } from './cached-alquila-tu-cancha.client';
+import { HTTPAlquilaTuCanchaClient } from './http-alquila-tu-cancha.client';
+
+describe('CachedAlquilaTuCanchaClient', () => {
+  let client: CachedAlquilaTuCanchaClient;
+  let httpClient: jest.Mocked<HTTPAlquilaTuCanchaClient>;
+  let cache: jest.Mocked<RedisCacheService>;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        CachedAlquilaTuCanchaClient,
+        {
+          provide: HTTPAlquilaTuCanchaClient,
+          useValue: {
+            getClubs: jest.fn(),
+            getCourts: jest.fn(),
+            getAvailableSlots: jest.fn(),
+          },
+        },
+        {
+          provide: RedisCacheService,
+          useValue: {
+            getWithStale: jest.fn(),
+            get: jest.fn(),
+            set: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    client = module.get(CachedAlquilaTuCanchaClient);
+    httpClient = module.get(HTTPAlquilaTuCanchaClient);
+    cache = module.get(RedisCacheService);
+  });
+
+  describe('getClubs', () => {
+    it('should return cached clubs on cache hit', async () => {
+      const placeId = 'test-place';
+      const cachedClubs: Club[] = [{ id: 1 }, { id: 2 }];
+
+      cache.getWithStale.mockResolvedValue(cachedClubs);
+
+      const result = await client.getClubs(placeId);
+
+      expect(result).toEqual(cachedClubs);
+      expect(httpClient.getClubs).not.toHaveBeenCalled();
+    });
+
+    it('should fetch from HTTP and cache on cache miss', async () => {
+      const placeId = 'test-place';
+      const clubs: Club[] = [{ id: 1 }, { id: 2 }];
+
+      cache.getWithStale.mockResolvedValue(null);
+      httpClient.getClubs.mockResolvedValue(clubs);
+
+      const result = await client.getClubs(placeId);
+
+      expect(result).toEqual(clubs);
+      expect(httpClient.getClubs).toHaveBeenCalledWith(placeId);
+      expect(cache.set).toHaveBeenCalledWith(
+        CacheKeys.clubs(placeId),
+        clubs,
+        CacheTTL.CLUBS,
+      );
+    });
+
+    it('should store clubId->placeId index when fetching clubs', async () => {
+      const placeId = 'test-place';
+      const clubs: Club[] = [{ id: 1 }, { id: 2 }];
+
+      cache.getWithStale.mockResolvedValue(null);
+      httpClient.getClubs.mockResolvedValue(clubs);
+
+      await client.getClubs(placeId);
+
+      // Should store index for each club
+      expect(cache.set).toHaveBeenCalledWith(
+        CacheKeys.clubToPlace(1),
+        placeId,
+        CacheTTL.CLUB_TO_PLACE,
+      );
+      expect(cache.set).toHaveBeenCalledWith(
+        CacheKeys.clubToPlace(2),
+        placeId,
+        CacheTTL.CLUB_TO_PLACE,
+      );
+    });
+
+    it('should return stale data when HTTP fails', async () => {
+      const placeId = 'test-place';
+      const staleClubs: Club[] = [{ id: 1 }];
+
+      cache.getWithStale.mockResolvedValue(null);
+      httpClient.getClubs.mockRejectedValue(new Error('Mock is down'));
+      cache.get.mockResolvedValue(staleClubs);
+
+      const result = await client.getClubs(placeId);
+
+      expect(result).toEqual(staleClubs);
+    });
+  });
+});

--- a/src/infrastructure/clients/cached-alquila-tu-cancha.client.ts
+++ b/src/infrastructure/clients/cached-alquila-tu-cancha.client.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+import * as moment from 'moment';
+
+import { Club } from '../../domain/model/club';
+import { Court } from '../../domain/model/court';
+import { Slot } from '../../domain/model/slot';
+import { AlquilaTuCanchaClient } from '../../domain/ports/aquila-tu-cancha.client';
+import { CacheKeys, CacheTTL } from '../cache/cache-keys';
+import { RedisCacheService } from '../cache/redis-cache.service';
+import { HTTPAlquilaTuCanchaClient } from './http-alquila-tu-cancha.client';
+
+@Injectable()
+export class CachedAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
+  constructor(
+    private httpClient: HTTPAlquilaTuCanchaClient,
+    private cache: RedisCacheService,
+  ) {}
+
+  async getClubs(placeId: string): Promise<Club[]> {
+    const key = CacheKeys.clubs(placeId);
+    const cached = await this.cache.getWithStale<Club[]>(key);
+
+    if (cached) return cached;
+
+    try {
+      const clubs = await this.httpClient.getClubs(placeId);
+      await this.cache.set(key, clubs, CacheTTL.CLUBS);
+
+      for (const club of clubs) {
+        await this.cache.set(
+          CacheKeys.clubToPlace(club.id),
+          placeId,
+          CacheTTL.CLUB_TO_PLACE,
+        );
+      }
+
+      return clubs;
+    } catch (err) {
+      const stale = await this.cache.get<Club[]>(CacheKeys.stale(key));
+      if (stale) return stale;
+      throw err;
+    }
+  }
+
+  async getCourts(clubId: number): Promise<Court[]> {
+    const key = CacheKeys.courts(clubId);
+    const cached = await this.cache.getWithStale<Court[]>(key);
+
+    if (cached) return cached;
+
+    try {
+      const courts = await this.httpClient.getCourts(clubId);
+      await this.cache.set(key, courts, CacheTTL.COURTS);
+      return courts;
+    } catch (err) {
+      const stale = await this.cache.get<Court[]>(CacheKeys.stale(key));
+      if (stale) return stale;
+      throw err;
+    }
+  }
+
+  async getAvailableSlots(
+    clubId: number,
+    courtId: number,
+    date: Date,
+  ): Promise<Slot[]> {
+    const key = CacheKeys.slots(clubId, courtId, date);
+    const cached = await this.cache.getWithStale<Slot[]>(key);
+
+    if (cached) return cached;
+
+    try {
+      const slots = await this.httpClient.getAvailableSlots(
+        clubId,
+        courtId,
+        date,
+      );
+      await this.cache.set(key, slots, CacheTTL.SLOTS);
+      return slots;
+    } catch (err) {
+      const stale = await this.cache.get<Slot[]>(CacheKeys.stale(key));
+      if (stale) return stale;
+      throw err;
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -408,6 +408,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@ioredis/commands@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.4.0.tgz#9f657d51cdd5d2fdb8889592aa4a355546151f25"
+  integrity sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1658,6 +1663,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
+cluster-key-slot@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -1773,6 +1783,13 @@ debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   dependencies:
     ms "2.1.2"
 
+debug@^4.3.4:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -1799,6 +1816,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+denque@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -2596,6 +2618,21 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
+ioredis@^5.3.2:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.8.2.tgz#c7a228a26cf36f17a5a8011148836877780e2e14"
+  integrity sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==
+  dependencies:
+    "@ioredis/commands" "1.4.0"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -3256,6 +3293,16 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
+
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -3414,6 +3461,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 mute-stream@0.0.8:
   version "0.0.8"
@@ -3813,6 +3865,18 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
+
 reflect-metadata@0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
@@ -4109,6 +4173,11 @@ stack-utils@^2.0.3:
   integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Problema

El endpoint `/search` venía tardando cerca de ~18s y realizaba entre 20 y 30 requests por consulta a la API mock. La API además tiene rate limit (60 req/min), alta latencia y puede estar caída en cualquier momento, por lo que el endpoint terminaba siendo un cuello de botella.

---

## Enfoque

El foco de la solución fue atacar tres puntos concretos:

- Reducir latencia y cantidad de requests a la API usando cache.
- Mantener la información actualizada frente a cambios.
- Mejorar el tiempo de respuesta sin romper el rate limit existente.

La idea no fue eliminar la dependencia de la API, sino reducir su impacto y aislar sus limitaciones.

---

## Cache a nivel de componentes

En lugar de cachear el resultado completo de `/search`, opte por cachear partes reutilizables (clubs, courts y slots).

La opción de cachear el resultado final era más directa, pero la descarté porque:

- Perdía reutilización entre fechas.
- Complicaba la invalidación frente a eventos.
- Forzaba tiempos de expiración poco reales.

Con este enfoque, los datos más estáticos se reutilizan entre consultas y solo se recalcula lo más volátil.

---

## Stale fallback

Dado que el challenge prioriza devolver datos desactualizados antes que no devolver nada, se implementó un fallback a datos stale.

Cuando la mock API no responde y no hay datos frescos en cache, el sistema devuelve información vencida dentro de una ventana controlada, priorizando disponibilidad por sobre frescura absoluta.

---

## Índice reverso

Algunos eventos llegan con `clubId` pero sin `placeId`, que es necesario para invalidar de forma correcta ciertos datos en cache.

Para resolverlo, se guarda una relación inversa entre club y place al momento de consultar los clubes, que luego se usa para realizar invalidaciones precisas sin limpiar cache de forma innecesaria.

---

## Invalidación por eventos

El cache se invalida de forma selectiva según el tipo de evento recibido:

- Cambios de disponibilidad invalidan solo la información de esa cancha y fecha.
- Updates de canchas invalidan los datos de canchas del club.
- Updates de clubes invalidan información del club y, en el caso de cambios de horarios, también la disponibilidad asociada.

Siempre que fue posible se priorizó invalidación puntual, y solo en casos con impacto global se invalida un conjunto mayor de datos.

---

## Paralelización con límite de concurrencia

El handler original realizaba todas las consultas de forma secuencial. Se refactorizó para ejecutarlas en paralelo, aplicando un límite de concurrencia para no saturar la mock API.

Este cambio reduce de forma significativa el tiempo de la primera consulta, manteniendo el cumplimiento del rate limit.

---

## Resultados

Con estos cambios se logró reducir de manera considerable la latencia del endpoint y la cantidad de requests hacia la mock API. Cuando hay cache disponible, el endpoint no realiza llamadas externas, y al cambiar la fecha reutiliza los datos estáticos existentes.

---

## Tests

Se agregaron tests unitarios cubriendo los casos más críticos:

- Lógica de paralelización.
- Comportamiento del cache (hit, miss y fallback).
- Invalidación ante eventos de booking.

---

## Mejoras futuras

Con más tiempo se podrían sumar:

- Cache warming para consultas frecuentes.
- Circuit breaker para Redis.
- Métricas de cache y latencia.
- Expiraciones configurables vía variables de entorno.
- Tests E2E del endpoint `/search`.

---

## Decisiones e investigación

### Referencias consultadas
- Patrón Cache-Aside: https://learn.microsoft.com/es-es/azure/architecture/patterns/cache-aside?utm_source=chatgpt.com
- Decorator Pattern: https://refactoring.guru/design-patterns/decorator
- Stale-While-Revalidate: https://web.dev/articles/stale-while-revalidate
- NestJS Caching: https://docs.nestjs.com/techniques/caching
- ioredis: https://github.com/redis/ioredis

### Decisiones principales

- **Redis vs cache en memoria**  
  Fui con Redis para tener cache compartido entre instancias, expiración automática y mejor observabilidad. También deja el camino abierto a escalar horizontal si hiciera falta.

- **Cache granular (clubs/courts/slots) vs resultado completo**  
  Consideré cachear el resultado completo de `/search`, pero lo descarté porque perdía reutilización entre fechas y complicaba la invalidación por eventos. Con cache granular se reutiliza lo estático y se invalida solo lo necesario.

- **Decorator pattern**  
  Agregué cache sin meter lógica en el dominio ni romper la arquitectura hexagonal. El handler sigue hablando con el mismo puerto.

- **Índice reverso (clubId -> placeId)**  
  Surgió porque algunos eventos traen `clubId` pero no `placeId`, y se necesitaba esa relación para invalidar correctamente ciertas entradas.

- **TTLs**  
  Probé valores distintos y me quedé con un balance razonable:
  - clubs: 1h
  - courts: 1h
  - slots: 2min

- **Concurrencia (límite 10)**  
  Se agregó paralelización con un límite fijo para acelerar los cache miss sin saturar la mock API. Con cache hits la cantidad de llamadas externas cae muchísimo, así que el “peor caso” se concentra principalmente en misses.
