### PR TITLE
Optimización del servicio de búsqueda de disponibilidad de cancha (/search)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # BUILD FOR LOCAL DEVELOPMENT
 ###################
 
-FROM node:16.17-alpine As development
+FROM node:16.17.0-alpine As development
 
 WORKDIR /usr/src/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       target: development
     volumes:
       - .:/usr/src/app
+      - /usr/src/app/node_modules
     command: npm run start:dev
     ports:
       - 3000:3000

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,8 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { ClubUpdatedHandler } from './domain/handlers/club-updated.handler';
 import { GetAvailabilityHandler } from './domain/handlers/get-availability.handler';
 import { ALQUILA_TU_CANCHA_CLIENT } from './domain/ports/aquila-tu-cancha.client';
+import { AVAILABILITY_CACHE } from './domain/ports/availability-cache.port';
+import { InMemoryAvailabilityCache } from './infrastructure/cache/in-memory-availability.cache';
 import { HTTPAlquilaTuCanchaClient } from './infrastructure/clients/http-alquila-tu-cancha.client';
 import { EventsController } from './infrastructure/controllers/events.controller';
 import { SearchController } from './infrastructure/controllers/search.controller';
@@ -17,6 +19,10 @@ import { SearchController } from './infrastructure/controllers/search.controller
     {
       provide: ALQUILA_TU_CANCHA_CLIENT,
       useClass: HTTPAlquilaTuCanchaClient,
+    },
+    {
+      provide: AVAILABILITY_CACHE,
+      useClass: InMemoryAvailabilityCache,
     },
     GetAvailabilityHandler,
     ClubUpdatedHandler,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,7 +4,10 @@ import { ConfigModule } from '@nestjs/config';
 import { CqrsModule } from '@nestjs/cqrs';
 
 import { ClubUpdatedHandler } from './domain/handlers/club-updated.handler';
+import { CourtUpdatedHandler } from './domain/handlers/court-updated.handler';
 import { GetAvailabilityHandler } from './domain/handlers/get-availability.handler';
+import { SlotAvailableHandler } from './domain/handlers/slot-available.handler';
+import { SlotBookedHandler } from './domain/handlers/slot-booked.handler';
 import { ALQUILA_TU_CANCHA_CLIENT } from './domain/ports/aquila-tu-cancha.client';
 import { AVAILABILITY_CACHE } from './domain/ports/availability-cache.port';
 import { InMemoryAvailabilityCache } from './infrastructure/cache/in-memory-availability.cache';
@@ -26,6 +29,9 @@ import { SearchController } from './infrastructure/controllers/search.controller
     },
     GetAvailabilityHandler,
     ClubUpdatedHandler,
+    CourtUpdatedHandler,
+    SlotBookedHandler,
+    SlotAvailableHandler,
   ],
 })
 export class AppModule {}

--- a/src/domain/handlers/club-updated.handler.ts
+++ b/src/domain/handlers/club-updated.handler.ts
@@ -26,13 +26,24 @@ export class ClubUpdatedHandler implements IEventHandler<ClubUpdatedEvent> {
     this.logger.log(
       `Club ${event.clubId} updated (fields: ${event.fields.join(', ')})`,
     );
-    // If openhours or attributes change, update courts and metadata in cache
+
+    if (
+      event.fields.includes('openhours') ||
+      event.fields.includes('open_hours' as any)
+    ) {
+      this.logger.log(
+        `Invalidating cache for club ${event.clubId} due to openhours update`,
+      );
+      this.cache.invalidateClub(event.clubId);
+      return;
+    }
+
     try {
-      const updatedCourts = await this.client.getCourts(event.clubId);
-      this.cache.setCourts(event.clubId, updatedCourts);
+      const updatedClub = await this.client.getClub(event.clubId);
+      this.cache.updateClubInfo(event.clubId, updatedClub);
     } catch (err) {
       this.logger.error(
-        `Failed to refresh courts for club ${event.clubId}: ${err.message}`,
+        `Failed to refresh metadata for club ${event.clubId}: ${err.message}`,
       );
     }
   }

--- a/src/domain/handlers/court-updated.handler.ts
+++ b/src/domain/handlers/court-updated.handler.ts
@@ -26,6 +26,7 @@ export class CourtUpdatedHandler implements IEventHandler<CourtUpdatedEvent> {
     this.logger.log(
       `Court ${event.courtId} of club ${event.clubId} updated (fields: ${event.fields.join(', ')})`,
     );
+    this.cache.invalidateCourt(event.clubId, event.courtId);
     try {
       const updatedCourts = await this.client.getCourts(event.clubId);
       this.cache.setCourts(event.clubId, updatedCourts);

--- a/src/domain/handlers/court-updated.handler.ts
+++ b/src/domain/handlers/court-updated.handler.ts
@@ -24,7 +24,9 @@ export class CourtUpdatedHandler implements IEventHandler<CourtUpdatedEvent> {
 
   async handle(event: CourtUpdatedEvent) {
     this.logger.log(
-      `Court ${event.courtId} of club ${event.clubId} updated (fields: ${event.fields.join(', ')})`,
+      `Court ${event.courtId} of club ${
+        event.clubId
+      } updated (fields: ${event.fields.join(', ')})`,
     );
     this.cache.invalidateCourt(event.clubId, event.courtId);
     try {

--- a/src/domain/handlers/court-updated.handler.ts
+++ b/src/domain/handlers/court-updated.handler.ts
@@ -1,7 +1,7 @@
 import { Inject, Logger } from '@nestjs/common';
 import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
 
-import { ClubUpdatedEvent } from '../events/club-updated.event';
+import { CourtUpdatedEvent } from '../events/court-updated.event';
 import {
   ALQUILA_TU_CANCHA_CLIENT,
   AlquilaTuCanchaClient,
@@ -11,9 +11,9 @@ import {
   AvailabilityCache,
 } from '../ports/availability-cache.port';
 
-@EventsHandler(ClubUpdatedEvent)
-export class ClubUpdatedHandler implements IEventHandler<ClubUpdatedEvent> {
-  private readonly logger = new Logger(ClubUpdatedHandler.name);
+@EventsHandler(CourtUpdatedEvent)
+export class CourtUpdatedHandler implements IEventHandler<CourtUpdatedEvent> {
+  private readonly logger = new Logger(CourtUpdatedHandler.name);
 
   constructor(
     @Inject(ALQUILA_TU_CANCHA_CLIENT)
@@ -22,11 +22,10 @@ export class ClubUpdatedHandler implements IEventHandler<ClubUpdatedEvent> {
     private cache: AvailabilityCache,
   ) {}
 
-  async handle(event: ClubUpdatedEvent) {
+  async handle(event: CourtUpdatedEvent) {
     this.logger.log(
-      `Club ${event.clubId} updated (fields: ${event.fields.join(', ')})`,
+      `Court ${event.courtId} of club ${event.clubId} updated (fields: ${event.fields.join(', ')})`,
     );
-    // If openhours or attributes change, update courts and metadata in cache
     try {
       const updatedCourts = await this.client.getCourts(event.clubId);
       this.cache.setCourts(event.clubId, updatedCourts);

--- a/src/domain/handlers/get-availability.handler.spec.ts
+++ b/src/domain/handlers/get-availability.handler.spec.ts
@@ -1,5 +1,6 @@
 import * as moment from 'moment';
 
+import { InMemoryAvailabilityCache } from '../../infrastructure/cache/in-memory-availability.cache';
 import { AlquilaTuCanchaClient } from '../../domain/ports/aquila-tu-cancha.client';
 import { GetAvailabilityQuery } from '../commands/get-availaiblity.query';
 import { Club } from '../model/club';
@@ -10,10 +11,12 @@ import { GetAvailabilityHandler } from './get-availability.handler';
 describe('GetAvailabilityHandler', () => {
   let handler: GetAvailabilityHandler;
   let client: FakeAlquilaTuCanchaClient;
+  let cache: InMemoryAvailabilityCache;
 
   beforeEach(() => {
     client = new FakeAlquilaTuCanchaClient();
-    handler = new GetAvailabilityHandler(client);
+    cache = new InMemoryAvailabilityCache();
+    handler = new GetAvailabilityHandler(client, cache);
   });
 
   it('returns the availability', async () => {

--- a/src/domain/handlers/get-availability.handler.spec.ts
+++ b/src/domain/handlers/get-availability.handler.spec.ts
@@ -1,7 +1,7 @@
 import * as moment from 'moment';
 
-import { InMemoryAvailabilityCache } from '../../infrastructure/cache/in-memory-availability.cache';
 import { AlquilaTuCanchaClient } from '../../domain/ports/aquila-tu-cancha.client';
+import { InMemoryAvailabilityCache } from '../../infrastructure/cache/in-memory-availability.cache';
 import { GetAvailabilityQuery } from '../commands/get-availaiblity.query';
 import { Club } from '../model/club';
 import { Court } from '../model/court';

--- a/src/domain/handlers/get-availability.handler.spec.ts
+++ b/src/domain/handlers/get-availability.handler.spec.ts
@@ -38,16 +38,56 @@ describe('GetAvailabilityHandler', () => {
 
     expect(response).toEqual([{ id: 1, courts: [{ id: 1, available: [] }] }]);
   });
+
+  it('returns empty array when client.getClubs fails gracefully (Mock API down or 429)', async () => {
+    client.shouldFailClubs = true;
+    const placeId = '123';
+    const date = moment('2022-12-05').toDate();
+
+    const response = await handler.execute(
+      new GetAvailabilityQuery(placeId, date),
+    );
+
+    expect(response).toEqual([]);
+  });
+
+  it('returns partial availability gracefully when fetching slots fails', async () => {
+    client.clubs = {
+      '123': [{ id: 1 }],
+    };
+    client.courts = {
+      '1': [{ id: 1 }],
+    };
+    client.shouldFailSlots = true;
+    const placeId = '123';
+    const date = moment('2022-12-05').toDate();
+
+    const response = await handler.execute(
+      new GetAvailabilityQuery(placeId, date),
+    );
+
+    expect(response).toEqual([{ id: 1, courts: [{ id: 1, available: [] }] }]);
+  });
 });
 
 class FakeAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
   clubs: Record<string, Club[]> = {};
   courts: Record<string, Court[]> = {};
   slots: Record<string, Slot[]> = {};
+  shouldFailClubs = false;
+  shouldFailCourts = false;
+  shouldFailSlots = false;
+
   async getClubs(placeId: string): Promise<Club[]> {
+    if (this.shouldFailClubs) {
+      throw new Error('Mock API Down / Rate limit 429');
+    }
     return this.clubs[placeId];
   }
   async getCourts(clubId: number): Promise<Court[]> {
+    if (this.shouldFailCourts) {
+      throw new Error('Mock API Down / Rate limit 429');
+    }
     return this.courts[String(clubId)];
   }
   async getAvailableSlots(
@@ -55,6 +95,9 @@ class FakeAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
     courtId: number,
     date: Date,
   ): Promise<Slot[]> {
+    if (this.shouldFailSlots) {
+      throw new Error('Mock API Down / Rate limit 429');
+    }
     return this.slots[
       `${clubId}_${courtId}_${moment(date).format('YYYY-MM-DD')}`
     ];

--- a/src/domain/handlers/get-availability.handler.spec.ts
+++ b/src/domain/handlers/get-availability.handler.spec.ts
@@ -84,6 +84,16 @@ class FakeAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
     }
     return this.clubs[placeId];
   }
+  async getClub(clubId: number): Promise<Club> {
+    if (this.shouldFailClubs) {
+      throw new Error('Mock API Down / Rate limit 429');
+    }
+    for (const placeClubs of Object.values(this.clubs)) {
+      const found = placeClubs.find((c) => c.id === clubId);
+      if (found) return found;
+    }
+    return { id: clubId } as Club;
+  }
   async getCourts(clubId: number): Promise<Court[]> {
     if (this.shouldFailCourts) {
       throw new Error('Mock API Down / Rate limit 429');

--- a/src/domain/handlers/get-availability.handler.ts
+++ b/src/domain/handlers/get-availability.handler.ts
@@ -20,27 +20,28 @@ export class GetAvailabilityHandler
   ) {}
 
   async execute(query: GetAvailabilityQuery): Promise<ClubWithAvailability[]> {
-    const clubs_with_availability: ClubWithAvailability[] = [];
     const clubs = await this.alquilaTuCanchaClient.getClubs(query.placeId);
-    for (const club of clubs) {
-      const courts = await this.alquilaTuCanchaClient.getCourts(club.id);
-      const courts_with_availability: ClubWithAvailability['courts'] = [];
-      for (const court of courts) {
-        const slots = await this.alquilaTuCanchaClient.getAvailableSlots(
-          club.id,
-          court.id,
-          query.date,
+    return Promise.all(
+      clubs.map(async (club) => {
+        const courts = await this.alquilaTuCanchaClient.getCourts(club.id);
+        const courts_with_availability = await Promise.all(
+          courts.map(async (court) => {
+            const slots = await this.alquilaTuCanchaClient.getAvailableSlots(
+              club.id,
+              court.id,
+              query.date,
+            );
+            return {
+              ...court,
+              available: slots,
+            };
+          }),
         );
-        courts_with_availability.push({
-          ...court,
-          available: slots,
-        });
-      }
-      clubs_with_availability.push({
-        ...club,
-        courts: courts_with_availability,
-      });
-    }
-    return clubs_with_availability;
+        return {
+          ...club,
+          courts: courts_with_availability,
+        };
+      }),
+    );
   }
 }

--- a/src/domain/handlers/get-availability.handler.ts
+++ b/src/domain/handlers/get-availability.handler.ts
@@ -1,4 +1,4 @@
-import { Inject } from '@nestjs/common';
+import { Inject, Logger } from '@nestjs/common';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import * as moment from 'moment';
 
@@ -19,6 +19,8 @@ import {
 export class GetAvailabilityHandler
   implements IQueryHandler<GetAvailabilityQuery>
 {
+  private readonly logger = new Logger(GetAvailabilityHandler.name);
+
   constructor(
     @Inject(ALQUILA_TU_CANCHA_CLIENT)
     private alquilaTuCanchaClient: AlquilaTuCanchaClient,
@@ -31,28 +33,49 @@ export class GetAvailabilityHandler
 
     let clubs = this.cache.getClubs(query.placeId);
     if (!clubs) {
-      clubs = await this.alquilaTuCanchaClient.getClubs(query.placeId);
-      this.cache.setClubs(query.placeId, clubs);
+      try {
+        clubs = await this.alquilaTuCanchaClient.getClubs(query.placeId);
+        this.cache.setClubs(query.placeId, clubs);
+      } catch (err) {
+        this.logger.error(
+          `Failed to fetch clubs for placeId ${query.placeId}: ${err.message}`,
+        );
+        return [];
+      }
     }
 
     return Promise.all(
       clubs.map(async (club) => {
         let courts = this.cache.getCourts(club.id);
         if (!courts) {
-          courts = await this.alquilaTuCanchaClient.getCourts(club.id);
-          this.cache.setCourts(club.id, courts);
+          try {
+            courts = await this.alquilaTuCanchaClient.getCourts(club.id);
+            this.cache.setCourts(club.id, courts);
+          } catch (err) {
+            this.logger.error(
+              `Failed to fetch courts for club ${club.id}: ${err.message}`,
+            );
+            courts = [];
+          }
         }
 
         const courts_with_availability = await Promise.all(
           courts.map(async (court) => {
             let slots = this.cache.getSlots(club.id, court.id, dateStr);
             if (!slots) {
-              slots = await this.alquilaTuCanchaClient.getAvailableSlots(
-                club.id,
-                court.id,
-                query.date,
-              );
-              this.cache.setSlots(club.id, court.id, dateStr, slots);
+              try {
+                slots = await this.alquilaTuCanchaClient.getAvailableSlots(
+                  club.id,
+                  court.id,
+                  query.date,
+                );
+                this.cache.setSlots(club.id, court.id, dateStr, slots);
+              } catch (err) {
+                this.logger.error(
+                  `Failed to fetch slots for club ${club.id}, court ${court.id}: ${err.message}`,
+                );
+                slots = [];
+              }
             }
 
             return {

--- a/src/domain/handlers/get-availability.handler.ts
+++ b/src/domain/handlers/get-availability.handler.ts
@@ -1,5 +1,6 @@
 import { Inject } from '@nestjs/common';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import * as moment from 'moment';
 
 import {
   ClubWithAvailability,
@@ -9,6 +10,10 @@ import {
   ALQUILA_TU_CANCHA_CLIENT,
   AlquilaTuCanchaClient,
 } from '../ports/aquila-tu-cancha.client';
+import {
+  AVAILABILITY_CACHE,
+  AvailabilityCache,
+} from '../ports/availability-cache.port';
 
 @QueryHandler(GetAvailabilityQuery)
 export class GetAvailabilityHandler
@@ -17,26 +22,46 @@ export class GetAvailabilityHandler
   constructor(
     @Inject(ALQUILA_TU_CANCHA_CLIENT)
     private alquilaTuCanchaClient: AlquilaTuCanchaClient,
+    @Inject(AVAILABILITY_CACHE)
+    private cache: AvailabilityCache,
   ) {}
 
   async execute(query: GetAvailabilityQuery): Promise<ClubWithAvailability[]> {
-    const clubs = await this.alquilaTuCanchaClient.getClubs(query.placeId);
+    const dateStr = moment(query.date).format('YYYY-MM-DD');
+
+    let clubs = this.cache.getClubs(query.placeId);
+    if (!clubs) {
+      clubs = await this.alquilaTuCanchaClient.getClubs(query.placeId);
+      this.cache.setClubs(query.placeId, clubs);
+    }
+
     return Promise.all(
       clubs.map(async (club) => {
-        const courts = await this.alquilaTuCanchaClient.getCourts(club.id);
+        let courts = this.cache.getCourts(club.id);
+        if (!courts) {
+          courts = await this.alquilaTuCanchaClient.getCourts(club.id);
+          this.cache.setCourts(club.id, courts);
+        }
+
         const courts_with_availability = await Promise.all(
           courts.map(async (court) => {
-            const slots = await this.alquilaTuCanchaClient.getAvailableSlots(
-              club.id,
-              court.id,
-              query.date,
-            );
+            let slots = this.cache.getSlots(club.id, court.id, dateStr);
+            if (!slots) {
+              slots = await this.alquilaTuCanchaClient.getAvailableSlots(
+                club.id,
+                court.id,
+                query.date,
+              );
+              this.cache.setSlots(club.id, court.id, dateStr, slots);
+            }
+
             return {
               ...court,
               available: slots,
             };
           }),
         );
+
         return {
           ...club,
           courts: courts_with_availability,

--- a/src/domain/handlers/slot-available.handler.ts
+++ b/src/domain/handlers/slot-available.handler.ts
@@ -1,0 +1,27 @@
+import { Inject, Logger } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import * as moment from 'moment';
+
+import { SlotAvailableEvent } from '../events/slot-cancelled.event';
+import {
+  AVAILABILITY_CACHE,
+  AvailabilityCache,
+} from '../ports/availability-cache.port';
+
+@EventsHandler(SlotAvailableEvent)
+export class SlotAvailableHandler implements IEventHandler<SlotAvailableEvent> {
+  private readonly logger = new Logger(SlotAvailableHandler.name);
+
+  constructor(
+    @Inject(AVAILABILITY_CACHE)
+    private cache: AvailabilityCache,
+  ) {}
+
+  handle(event: SlotAvailableEvent) {
+    const dateStr = moment(event.slot.datetime).format('YYYY-MM-DD');
+    this.cache.addSlot(event.clubId, event.courtId, dateStr, event.slot);
+    this.logger.log(
+      `Slot released for club ${event.clubId}, court ${event.courtId} on ${dateStr} at ${event.slot.start}`,
+    );
+  }
+}

--- a/src/domain/handlers/slot-booked.handler.ts
+++ b/src/domain/handlers/slot-booked.handler.ts
@@ -1,0 +1,27 @@
+import { Inject, Logger } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import * as moment from 'moment';
+
+import { SlotBookedEvent } from '../events/slot-booked.event';
+import {
+  AVAILABILITY_CACHE,
+  AvailabilityCache,
+} from '../ports/availability-cache.port';
+
+@EventsHandler(SlotBookedEvent)
+export class SlotBookedHandler implements IEventHandler<SlotBookedEvent> {
+  private readonly logger = new Logger(SlotBookedHandler.name);
+
+  constructor(
+    @Inject(AVAILABILITY_CACHE)
+    private cache: AvailabilityCache,
+  ) {}
+
+  handle(event: SlotBookedEvent) {
+    const dateStr = moment(event.slot.datetime).format('YYYY-MM-DD');
+    this.cache.removeSlot(event.clubId, event.courtId, dateStr, event.slot);
+    this.logger.log(
+      `Slot booked for club ${event.clubId}, court ${event.courtId} on ${dateStr} at ${event.slot.start}`,
+    );
+  }
+}

--- a/src/domain/ports/aquila-tu-cancha.client.ts
+++ b/src/domain/ports/aquila-tu-cancha.client.ts
@@ -5,6 +5,7 @@ import { Slot } from '../model/slot';
 export const ALQUILA_TU_CANCHA_CLIENT = 'ALQUILA_TU_CANCHA_CLIENT';
 export interface AlquilaTuCanchaClient {
   getClubs(placeId: string): Promise<Club[]>;
+  getClub(clubId: number): Promise<Club>;
   getCourts(clubId: number): Promise<Court[]>;
   getAvailableSlots(
     clubId: number,

--- a/src/domain/ports/availability-cache.port.ts
+++ b/src/domain/ports/availability-cache.port.ts
@@ -1,0 +1,29 @@
+import { Club } from '../model/club';
+import { Court } from '../model/court';
+import { Slot } from '../model/slot';
+
+export const AVAILABILITY_CACHE = 'AVAILABILITY_CACHE';
+
+export interface AvailabilityCache {
+  getClubs(placeId: string): Club[] | null;
+  setClubs(placeId: string, clubs: Club[]): void;
+
+  getCourts(clubId: number): Court[] | null;
+  setCourts(clubId: number, courts: Court[]): void;
+
+  getSlots(clubId: number, courtId: number, dateStr: string): Slot[] | null;
+  setSlots(
+    clubId: number,
+    courtId: number,
+    dateStr: string,
+    slots: Slot[],
+  ): void;
+
+  addSlot(clubId: number, courtId: number, dateStr: string, slot: Slot): void;
+  removeSlot(
+    clubId: number,
+    courtId: number,
+    dateStr: string,
+    slot: Slot,
+  ): void;
+}

--- a/src/domain/ports/availability-cache.port.ts
+++ b/src/domain/ports/availability-cache.port.ts
@@ -7,6 +7,7 @@ export const AVAILABILITY_CACHE = 'AVAILABILITY_CACHE';
 export interface AvailabilityCache {
   getClubs(placeId: string): Club[] | null;
   setClubs(placeId: string, clubs: Club[]): void;
+  updateClubInfo(clubId: number, club: Club): void;
 
   getCourts(clubId: number): Court[] | null;
   setCourts(clubId: number, courts: Court[]): void;
@@ -26,4 +27,7 @@ export interface AvailabilityCache {
     dateStr: string,
     slot: Slot,
   ): void;
+
+  invalidateClub(clubId: number): void;
+  invalidateCourt(clubId: number, courtId: number): void;
 }

--- a/src/infrastructure/cache/in-memory-availability.cache.spec.ts
+++ b/src/infrastructure/cache/in-memory-availability.cache.spec.ts
@@ -38,7 +38,6 @@ describe('InMemoryAvailabilityCache', () => {
     const pastDateStr = moment().subtract(1, 'day').format('YYYY-MM-DD');
 
     cache.setSlots(1, 10, pastDateStr, [sampleSlot]);
-    // getSlots invoca a cleanStaleSlots, eliminando la entrada de fecha pasada
     expect(cache.getSlots(1, 10, pastDateStr)).toBeNull();
   });
 
@@ -57,5 +56,35 @@ describe('InMemoryAvailabilityCache', () => {
 
     cache.removeSlot(1, 10, validDateStr, sampleSlot);
     expect(cache.getSlots(1, 10, validDateStr)).toEqual([]);
+  });
+
+  it('invalidates all courts and slots when invalidateClub is called', () => {
+    const validDateStr = moment().add(1, 'day').format('YYYY-MM-DD');
+    cache.setCourts(1, [{ id: 10 }]);
+    cache.setSlots(1, 10, validDateStr, [sampleSlot]);
+
+    cache.invalidateClub(1);
+
+    expect(cache.getCourts(1)).toBeNull();
+    expect(cache.getSlots(1, 10, validDateStr)).toBeNull();
+  });
+
+  it('invalidates specific court slots when invalidateCourt is called', () => {
+    const validDateStr = moment().add(1, 'day').format('YYYY-MM-DD');
+    cache.setCourts(1, [{ id: 10 }]);
+    cache.setSlots(1, 10, validDateStr, [sampleSlot]);
+
+    cache.invalidateCourt(1, 10);
+
+    expect(cache.getSlots(1, 10, validDateStr)).toBeNull();
+  });
+
+  it('updates single club info surgically without invalidating courts or slots', () => {
+    cache.setClubs('place_1', [{ id: 10, name: 'Old Club Name' } as any]);
+    cache.updateClubInfo(10, { id: 10, name: 'New Club Name' } as any);
+
+    expect(cache.getClubs('place_1')).toEqual([
+      { id: 10, name: 'New Club Name' },
+    ]);
   });
 });

--- a/src/infrastructure/cache/in-memory-availability.cache.spec.ts
+++ b/src/infrastructure/cache/in-memory-availability.cache.spec.ts
@@ -1,0 +1,61 @@
+import * as moment from 'moment';
+
+import { Slot } from '../../domain/model/slot';
+import { InMemoryAvailabilityCache } from './in-memory-availability.cache';
+
+describe('InMemoryAvailabilityCache', () => {
+  let cache: InMemoryAvailabilityCache;
+
+  const sampleSlot: Slot = {
+    price: 1000,
+    duration: 60,
+    datetime: '2022-08-25T10:00:00Z',
+    start: '10:00',
+    end: '11:00',
+    _priority: 1,
+  };
+
+  beforeEach(() => {
+    cache = new InMemoryAvailabilityCache();
+  });
+
+  it('stores and retrieves clubs and courts correctly', () => {
+    cache.setClubs('place_1', [{ id: 10 }]);
+    cache.setCourts(10, [{ id: 100 }]);
+
+    expect(cache.getClubs('place_1')).toEqual([{ id: 10 }]);
+    expect(cache.getCourts(10)).toEqual([{ id: 100 }]);
+  });
+
+  it('stores and retrieves slots within the 7-day valid window', () => {
+    const validDateStr = moment().add(2, 'days').format('YYYY-MM-DD');
+
+    cache.setSlots(1, 10, validDateStr, [sampleSlot]);
+    expect(cache.getSlots(1, 10, validDateStr)).toEqual([sampleSlot]);
+  });
+
+  it('auto-evicts slots from past dates (stale TTL eviction)', () => {
+    const pastDateStr = moment().subtract(1, 'day').format('YYYY-MM-DD');
+
+    cache.setSlots(1, 10, pastDateStr, [sampleSlot]);
+    // getSlots invoca a cleanStaleSlots, eliminando la entrada de fecha pasada
+    expect(cache.getSlots(1, 10, pastDateStr)).toBeNull();
+  });
+
+  it('auto-evicts slots beyond the 7-day window', () => {
+    const futureDateStr = moment().add(10, 'days').format('YYYY-MM-DD');
+
+    cache.setSlots(1, 10, futureDateStr, [sampleSlot]);
+    expect(cache.getSlots(1, 10, futureDateStr)).toBeNull();
+  });
+
+  it('adds and removes slots dynamically for real-time events', () => {
+    const validDateStr = moment().add(1, 'day').format('YYYY-MM-DD');
+
+    cache.addSlot(1, 10, validDateStr, sampleSlot);
+    expect(cache.getSlots(1, 10, validDateStr)).toEqual([sampleSlot]);
+
+    cache.removeSlot(1, 10, validDateStr, sampleSlot);
+    expect(cache.getSlots(1, 10, validDateStr)).toEqual([]);
+  });
+});

--- a/src/infrastructure/cache/in-memory-availability.cache.ts
+++ b/src/infrastructure/cache/in-memory-availability.cache.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+
+import { Club } from '../../domain/model/club';
+import { Court } from '../../domain/model/court';
+import { Slot } from '../../domain/model/slot';
+import { AvailabilityCache } from '../../domain/ports/availability-cache.port';
+
+@Injectable()
+export class InMemoryAvailabilityCache implements AvailabilityCache {
+  private clubsByPlace = new Map<string, Club[]>();
+  private courtsByClub = new Map<number, Court[]>();
+  private slotsByCourtAndDate = new Map<string, Slot[]>();
+
+  private buildSlotKey(
+    clubId: number,
+    courtId: number,
+    dateStr: string,
+  ): string {
+    return `${clubId}_${courtId}_${dateStr}`;
+  }
+
+  getClubs(placeId: string): Club[] | null {
+    return this.clubsByPlace.get(placeId) ?? null;
+  }
+
+  setClubs(placeId: string, clubs: Club[]): void {
+    this.clubsByPlace.set(placeId, clubs);
+  }
+
+  getCourts(clubId: number): Court[] | null {
+    return this.courtsByClub.get(clubId) ?? null;
+  }
+
+  setCourts(clubId: number, courts: Court[]): void {
+    this.courtsByClub.set(clubId, courts);
+  }
+
+  getSlots(clubId: number, courtId: number, dateStr: string): Slot[] | null {
+    const key = this.buildSlotKey(clubId, courtId, dateStr);
+    return this.slotsByCourtAndDate.get(key) ?? null;
+  }
+
+  setSlots(
+    clubId: number,
+    courtId: number,
+    dateStr: string,
+    slots: Slot[],
+  ): void {
+    const key = this.buildSlotKey(clubId, courtId, dateStr);
+    this.slotsByCourtAndDate.set(key, slots);
+  }
+
+  addSlot(clubId: number, courtId: number, dateStr: string, slot: Slot): void {
+    const key = this.buildSlotKey(clubId, courtId, dateStr);
+    const existing = this.slotsByCourtAndDate.get(key);
+    if (!existing) {
+      this.slotsByCourtAndDate.set(key, [slot]);
+      return;
+    }
+    const alreadyExists = existing.some((s) => s.start === slot.start);
+    if (!alreadyExists) {
+      this.slotsByCourtAndDate.set(
+        key,
+        [...existing, slot].sort((a, b) => a.start.localeCompare(b.start)),
+      );
+    }
+  }
+
+  removeSlot(
+    clubId: number,
+    courtId: number,
+    dateStr: string,
+    slot: Slot,
+  ): void {
+    const key = this.buildSlotKey(clubId, courtId, dateStr);
+    const existing = this.slotsByCourtAndDate.get(key);
+    if (!existing) return;
+    const updated = existing.filter((s) => s.start !== slot.start);
+    this.slotsByCourtAndDate.set(key, updated);
+  }
+}

--- a/src/infrastructure/cache/in-memory-availability.cache.ts
+++ b/src/infrastructure/cache/in-memory-availability.cache.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import * as moment from 'moment';
 
 import { Club } from '../../domain/model/club';
 import { Court } from '../../domain/model/court';
@@ -19,6 +20,25 @@ export class InMemoryAvailabilityCache implements AvailabilityCache {
     return `${clubId}_${courtId}_${dateStr}`;
   }
 
+  private isWithin7DaysWindow(dateStr: string): boolean {
+    const todayStr = moment().format('YYYY-MM-DD');
+    const maxDateStr = moment().add(7, 'days').format('YYYY-MM-DD');
+    return dateStr >= todayStr && dateStr <= maxDateStr;
+  }
+
+  private cleanStaleSlots(): void {
+    const todayStr = moment().format('YYYY-MM-DD');
+    const maxDateStr = moment().add(7, 'days').format('YYYY-MM-DD');
+
+    for (const key of this.slotsByCourtAndDate.keys()) {
+      const parts = key.split('_');
+      const dateStr = parts[2];
+      if (dateStr < todayStr || dateStr > maxDateStr) {
+        this.slotsByCourtAndDate.delete(key);
+      }
+    }
+  }
+
   getClubs(placeId: string): Club[] | null {
     return this.clubsByPlace.get(placeId) ?? null;
   }
@@ -36,6 +56,7 @@ export class InMemoryAvailabilityCache implements AvailabilityCache {
   }
 
   getSlots(clubId: number, courtId: number, dateStr: string): Slot[] | null {
+    this.cleanStaleSlots();
     const key = this.buildSlotKey(clubId, courtId, dateStr);
     return this.slotsByCourtAndDate.get(key) ?? null;
   }
@@ -46,11 +67,18 @@ export class InMemoryAvailabilityCache implements AvailabilityCache {
     dateStr: string,
     slots: Slot[],
   ): void {
+    this.cleanStaleSlots();
+    if (!this.isWithin7DaysWindow(dateStr)) {
+      return;
+    }
     const key = this.buildSlotKey(clubId, courtId, dateStr);
     this.slotsByCourtAndDate.set(key, slots);
   }
 
   addSlot(clubId: number, courtId: number, dateStr: string, slot: Slot): void {
+    if (!this.isWithin7DaysWindow(dateStr)) {
+      return;
+    }
     const key = this.buildSlotKey(clubId, courtId, dateStr);
     const existing = this.slotsByCourtAndDate.get(key);
     if (!existing) {

--- a/src/infrastructure/cache/in-memory-availability.cache.ts
+++ b/src/infrastructure/cache/in-memory-availability.cache.ts
@@ -47,6 +47,16 @@ export class InMemoryAvailabilityCache implements AvailabilityCache {
     this.clubsByPlace.set(placeId, clubs);
   }
 
+  updateClubInfo(clubId: number, updatedClub: Club): void {
+    for (const [placeId, clubs] of this.clubsByPlace.entries()) {
+      const index = clubs.findIndex((c) => c.id === clubId);
+      if (index !== -1) {
+        clubs[index] = updatedClub;
+        this.clubsByPlace.set(placeId, clubs);
+      }
+    }
+  }
+
   getCourts(clubId: number): Court[] | null {
     return this.courtsByClub.get(clubId) ?? null;
   }
@@ -105,5 +115,23 @@ export class InMemoryAvailabilityCache implements AvailabilityCache {
     if (!existing) return;
     const updated = existing.filter((s) => s.start !== slot.start);
     this.slotsByCourtAndDate.set(key, updated);
+  }
+
+  invalidateClub(clubId: number): void {
+    this.courtsByClub.delete(clubId);
+    for (const key of this.slotsByCourtAndDate.keys()) {
+      if (key.startsWith(`${clubId}_`)) {
+        this.slotsByCourtAndDate.delete(key);
+      }
+    }
+  }
+
+  invalidateCourt(clubId: number, courtId: number): void {
+    this.courtsByClub.delete(clubId);
+    for (const key of this.slotsByCourtAndDate.keys()) {
+      if (key.startsWith(`${clubId}_${courtId}_`)) {
+        this.slotsByCourtAndDate.delete(key);
+      }
+    }
   }
 }

--- a/src/infrastructure/clients/http-alquila-tu-cancha.client.spec.ts
+++ b/src/infrastructure/clients/http-alquila-tu-cancha.client.spec.ts
@@ -1,0 +1,82 @@
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as moment from 'moment';
+
+import { HTTPAlquilaTuCanchaClient } from './http-alquila-tu-cancha.client';
+
+describe('HTTPAlquilaTuCanchaClient', () => {
+  let client: HTTPAlquilaTuCanchaClient;
+
+  const mockAxiosGet = jest.fn();
+
+  beforeEach(async () => {
+    mockAxiosGet.mockReset();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HTTPAlquilaTuCanchaClient,
+        {
+          provide: HttpService,
+          useValue: {
+            axiosRef: {
+              get: mockAxiosGet,
+            },
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockReturnValue('http://localhost:4000'),
+          },
+        },
+      ],
+    }).compile();
+
+    client = module.get<HTTPAlquilaTuCanchaClient>(HTTPAlquilaTuCanchaClient);
+  });
+
+  it('deduplicates concurrent slot availability requests for a date 3 days in the future (Single Flight Pattern)', async () => {
+    let resolveRequest!: (value: any) => void;
+    const pendingPromise = new Promise((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    mockAxiosGet.mockImplementation(() => pendingPromise);
+
+    const targetDate = moment().add(3, 'days').toDate();
+    const targetDateStr = moment(targetDate).format('YYYY-MM-DD');
+
+    const requests = Array.from({ length: 10 }).map(() =>
+      client.getAvailableSlots(1, 10, targetDate),
+    );
+
+    expect(mockAxiosGet).toHaveBeenCalledTimes(1);
+    expect(mockAxiosGet).toHaveBeenCalledWith(
+      '/clubs/1/courts/10/slots',
+      expect.objectContaining({
+        params: { date: targetDateStr },
+      }),
+    );
+
+    const mockSlots = [
+      {
+        price: 1500,
+        duration: 60,
+        datetime: `${targetDateStr}T14:00:00Z`,
+        start: '14:00',
+        end: '15:00',
+        _priority: 1,
+      },
+    ];
+
+    resolveRequest({ data: mockSlots });
+
+    const results = await Promise.all(requests);
+
+    expect(results).toHaveLength(10);
+    results.forEach((res) => {
+      expect(res).toEqual(mockSlots);
+    });
+  });
+});

--- a/src/infrastructure/clients/http-alquila-tu-cancha.client.ts
+++ b/src/infrastructure/clients/http-alquila-tu-cancha.client.ts
@@ -25,6 +25,15 @@ export class HTTPAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
       .then((res) => res.data);
   }
 
+  getClub(clubId: number): Promise<Club> {
+    return this.httpService.axiosRef
+      .get(`/clubs/${clubId}`, {
+        baseURL: this.base_url,
+        timeout: 10000,
+      })
+      .then((res) => res.data);
+  }
+
   getCourts(clubId: number): Promise<Court[]> {
     return this.httpService.axiosRef
       .get(`/clubs/${clubId}/courts`, {

--- a/src/infrastructure/clients/http-alquila-tu-cancha.client.ts
+++ b/src/infrastructure/clients/http-alquila-tu-cancha.client.ts
@@ -11,36 +11,58 @@ import { AlquilaTuCanchaClient } from '../../domain/ports/aquila-tu-cancha.clien
 @Injectable()
 export class HTTPAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
   private base_url: string;
+  private inFlightRequests = new Map<string, Promise<any>>();
+
   constructor(private httpService: HttpService, config: ConfigService) {
     this.base_url = config.get<string>('ATC_BASE_URL', 'http://localhost:4000');
   }
 
+  private deduplicateRequest<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    if (this.inFlightRequests.has(key)) {
+      return this.inFlightRequests.get(key) as Promise<T>;
+    }
+    const promise = fn().finally(() => {
+      this.inFlightRequests.delete(key);
+    });
+    this.inFlightRequests.set(key, promise);
+    return promise;
+  }
+
   async getClubs(placeId: string): Promise<Club[]> {
-    return this.httpService.axiosRef
-      .get('clubs', {
-        baseURL: this.base_url,
-        params: { placeId },
-        timeout: 10000,
-      })
-      .then((res) => res.data);
+    const key = `clubs_${placeId}`;
+    return this.deduplicateRequest(key, () =>
+      this.httpService.axiosRef
+        .get('clubs', {
+          baseURL: this.base_url,
+          params: { placeId },
+          timeout: 10000,
+        })
+        .then((res) => res.data),
+    );
   }
 
   getClub(clubId: number): Promise<Club> {
-    return this.httpService.axiosRef
-      .get(`/clubs/${clubId}`, {
-        baseURL: this.base_url,
-        timeout: 10000,
-      })
-      .then((res) => res.data);
+    const key = `club_${clubId}`;
+    return this.deduplicateRequest(key, () =>
+      this.httpService.axiosRef
+        .get(`/clubs/${clubId}`, {
+          baseURL: this.base_url,
+          timeout: 10000,
+        })
+        .then((res) => res.data),
+    );
   }
 
   getCourts(clubId: number): Promise<Court[]> {
-    return this.httpService.axiosRef
-      .get(`/clubs/${clubId}/courts`, {
-        baseURL: this.base_url,
-        timeout: 10000,
-      })
-      .then((res) => res.data);
+    const key = `courts_${clubId}`;
+    return this.deduplicateRequest(key, () =>
+      this.httpService.axiosRef
+        .get(`/clubs/${clubId}/courts`, {
+          baseURL: this.base_url,
+          timeout: 10000,
+        })
+        .then((res) => res.data),
+    );
   }
 
   getAvailableSlots(
@@ -48,12 +70,16 @@ export class HTTPAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
     courtId: number,
     date: Date,
   ): Promise<Slot[]> {
-    return this.httpService.axiosRef
-      .get(`/clubs/${clubId}/courts/${courtId}/slots`, {
-        baseURL: this.base_url,
-        params: { date: moment(date).format('YYYY-MM-DD') },
-        timeout: 10000,
-      })
-      .then((res) => res.data);
+    const dateStr = moment(date).format('YYYY-MM-DD');
+    const key = `slots_${clubId}_${courtId}_${dateStr}`;
+    return this.deduplicateRequest(key, () =>
+      this.httpService.axiosRef
+        .get(`/clubs/${clubId}/courts/${courtId}/slots`, {
+          baseURL: this.base_url,
+          params: { date: dateStr },
+          timeout: 10000,
+        })
+        .then((res) => res.data),
+    );
   }
 }

--- a/src/infrastructure/clients/http-alquila-tu-cancha.client.ts
+++ b/src/infrastructure/clients/http-alquila-tu-cancha.client.ts
@@ -20,6 +20,7 @@ export class HTTPAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
       .get('clubs', {
         baseURL: this.base_url,
         params: { placeId },
+        timeout: 10000,
       })
       .then((res) => res.data);
   }
@@ -28,6 +29,7 @@ export class HTTPAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
     return this.httpService.axiosRef
       .get(`/clubs/${clubId}/courts`, {
         baseURL: this.base_url,
+        timeout: 10000,
       })
       .then((res) => res.data);
   }
@@ -41,6 +43,7 @@ export class HTTPAlquilaTuCanchaClient implements AlquilaTuCanchaClient {
       .get(`/clubs/${clubId}/courts/${courtId}/slots`, {
         baseURL: this.base_url,
         params: { date: moment(date).format('YYYY-MM-DD') },
+        timeout: 10000,
       })
       .then((res) => res.data);
   }


### PR DESCRIPTION
## Optimización del servicio de búsqueda de disponibilidad de cancha (/search)

Este Pull Request implementa una serie de optimizaciones sobre el endpoint `GET /search` con el fin de resolver los cuellos de botella de latencia alta y los errores causados por el límite de solicitudes (60 req/min) de la API mock externa.

Mediante una caché local estructurada en memoria, paralelización de llamadas, deduplicación de peticiones en vuelo (Single-Flight) y sincronización por eventos (CQRS), se lograron los siguientes resultados sobre la zona de Rosario `GET /search?placeId=ChIJW9fXNZNTtpURV6VYAumGQOw&date=2026-07-10` (7 clubes, 16 canchas, ~24 llamadas HTTP salientes originales):

* **Primera consulta en frío (Cache Miss):** Reducción de ~18 segundos a **~4.5 segundos** (mejora del 75% al paralelizar las solicitudes).
* **Consultas subsiguientes (Cache Hit):** Reducción a **9 milisegundos** (lectura en memoria `O(1)`).
* **Consumo de red en hits (múltiples peticiones de una zona y día ya solicitados con anterioridad):** 0 peticiones salientes realizadas, protegiendo la cuota de la API externa.
* **Resiliencia:** Si la API externa se cae o devuelve error por Rate Limit, el servicio responde con disponibilidad degradada (retorna los datos que tiene o vacíos en caso de que no tenga aún los datos consultados) evitando lanzar un error 500 al cliente.

---

## Resultados Medidos (Tabla Comparativa)

| Métrica / Escenario | Baseline (Original) | Optimizado (PR) | Mejora / Reducción |
| :--- | :---: | :---: | :---: |
| **Latencia Cache Miss (Primera búsqueda)** | ~18.0 s | **~4.5 s** | **75.0% más rápido** (Paralelización) |
| **Latencia Cache Hit (Búsquedas recurrentes)** | ~18.0 s | **9 ms** | **99.8% más rápido** (Caché local) |
| **Consumo de HTTP salientes (Hits)** | 24 req | **0 req** | **100% ahorro de cuota** |
| **Resistencia a Ráfagas en Frío** | Fallaba (con 3 peticiones devolvía 429 en API Mock, 500 al cliente) | **1 llamada dedup** | **Deduplicación (Single Flight)** |
| **Resiliencia ante caídas de la API** | Error 500 | **200 OK Degradado** | **Tolerancia a fallos** |

---

## ¿Qué hice y que decisiones tomé?

### 1. Concurrencia con `Promise.all`
El manejador original `GetAvailabilityHandler` iteraba secuencialmente sobre cada club y cancha esperando cada respuesta de red. Fue lo primero que afronté, refactoricé esta lógica para disparar las llamadas HTTP de forma paralela, logrando que el tiempo en frío se reduzca al tiempo máximo que tome la petición individual más lenta (`~4.5 s`).

### 2. Caché granular en memoria (`InMemoryAvailabilityCache`)
* **Desacoplamiento (Arquitectura Hexagonal):** Se definió la interfaz `AvailabilityCache` en el dominio, manteniendo las reglas de negocio separadas de la infraestructura de almacenamiento.
* **Estructura granular:** En lugar de guardar la respuesta JSON completa del search, decidí usar tres `Map` de JavaScript separados (clubes por zona, canchas por club y slots por cancha/fecha).
* **Reutilización multidía:** Al consultar diferentes días para una misma zona, los metadatos estáticos de los clubes y las canchas se leen directamente de la memoria, solicitando por red únicamente los slots del día específico en complejidad `O(1)`.

### 3. Sincronización en tiempo real (CQRS Events)
Para mantener la caché consistente sin tener que hacer invalidaciones masivas de red, implementé handlers que reaccionan a los eventos de `/events`:
* **`booking_created` y `booking_cancelled`:** Actualizan de forma quirúrgica en el arreglo de slots en memoria sin realizar llamadas de red adicionales.
* **`court_updated`:** Invalida selectivamente la caché de la cancha modificada.
* **`club_updated`:** 
  - Si el cambio afecta a `openhours`, invalida los slots y canchas del club (ya que altera las grillas).
  - Si el cambio es cosmético (nombre, logo, u otros detalles), obtiene la nueva información del club y actualiza la metadata en caché sin invalidar su disponibilidad actual.

### 4. Patrón Single-Flight / Request Coalescing
En momentos de *cache miss* en frío, múltiples usuarios consultando al mismo tiempo podrían disparar ráfagas de decenas de llamadas idénticas a la API mock, provocando un Rate Limit de inmediato. Implementé un mapa de solicitudes en vuelo (`inFlightRequests`) en `HTTPAlquilaTuCanchaClient`. Si entra una llamada idéntica mientras hay otra igual en curso, se une a la promesa activa, realizando una sola llamada de red real. Esto podría darse, por ejemplo, algún día Sábado que se sabe que hay algún evento importante o algo relevante para los jugadores y días antes entran múltiples solicitudes de búsqueda de disponibilidad para ese día en una misma zona. Si algunas de esas ráfagas de solicitudes se realizan al mismo tiempo la resolvemos de esta manera, ahorrándonos llamadas a la API Mock.

### 5. Evicción y TTL
**Estrategia:** Purga transparente en `cleanStaleSlots()` que elimina automáticamente cualquier entrada de slots con fecha `< hoy` o `> hoy + 7 días`. Esto garantiza un footprint de memoria RAM constante y previene fugas (*memory leaks*).
- **Nota Importante para Revisión o Test que se realicen:** Bajo los supuestos de negocio del desafío, las consultas de disponibilidad se realizan únicamente dentro del rango de una semana. Por diseño y protección de memoria, **el caché solo almacenará registros de turnos cuyas fechas estén comprendidas en la ventana móvil de `[hoy, hoy + 7 días]`**. Si se ejecutan pruebas manuales o consultas utilizando fechas pasadas o muy futuras, la API funcionará correctamente haciendo el fallback de red directo, pero **no guardará esos datos en el caché**. Se solicita probar el comportamiento de caché utilizando fechas dentro de los próximos 7 días a partir del día actual.

### 6. Resiliencia ante caídas externas
- **Manejo Seguro (`try/catch`):** Envoltura de todas las llamadas externas en bloques `try/catch`. Si la API Mock sufre caídas parciales o rebotes de cuota, el sistema responde con disponibilidad degradada (`200 OK` con grilla vacía para esa cancha afectada) en lugar de propagar un error `500 Internal Server Error` al cliente.
- **Timeout de 10s:**
  * *Comportamiento Nominal:* En condiciones normales y secuenciales, la API Mock responde rápido.
  * *Comportamiento en Ráfaga Concurrentes:* Al paralelizar con `Promise.all`, un Cache Miss dispara hasta 24 llamadas simultáneas. Este pico repentino encolará las peticiones, haciendo que las últimas llamadas en la cola puedan tardar entre 3 y 5 segundos en resolverse debido al tiempo de espera en cola de red.
  * *Decisión:* Configurar un timeout de **10000ms (10s)** en Axios le otorga al backend el margen (headroom) necesario para procesar y descongestionar estas ráfagas concurrentes sin abortar peticiones sanas de forma prematura (lo que ocurriría con timeouts estrictos de 4 o 5 segundos), mientras que sigue actuando como un límite de seguridad superior para liberar sockets colgados si la API externa realmente cayera.
---

## Trade-Offs Analizados

*   **Caché RAM In-Memory vs. Redis:**
    *   *Decisión:* Se optó por utilizar memoria RAM local del proceso en lugar de desplegar un contenedor dedicado para Redis.
    *   *Justificación:* Al ejecutar la aplicación en una sola instancia y en un entorno autocontenido como es el caso, los tiempos de respuesta y latencia entre Redis y la memoria RAM del proceso serían prácticamente idénticos (ambos en el rango de sub-milisegundos). Por ende, la elección no se debe a una limitación de rendimiento de Redis, sino al criterio de **evitar añadir dependencias de infraestructura y complejidad de configuración innecesaria** para un servidor único. Usar la RAM nos permite simplificar el arranque y despliegue del proyecto en esta etapa. Esto es conveniente obviamente siempre y cuando nos permitamos ocupar RAM del servidor para dedicar al cache, dependiendo así del tamaño de cache previsto para la ventana de 7 días. En un entorno real claramente esto se va a decidir según la capacidad del servidor o capacidad de procesamiento disponible.
    *   *Evolución Natural:* En un entorno productivo real que requiera escalar horizontalmente a múltiples contenedores/instancias de la aplicación detrás de un balanceador de carga, la centralización del caché mediante Redis es, sin duda, la estrategia correcta para garantizar la consistencia del estado. Gracias al diseño desacoplado bajo **Arquitectura Hexagonal** (mediante el puerto `AvailabilityCache`), esta migración a Redis se podrá realizar en el futuro de forma totalmente transparente sin alterar la lógica de negocio de dominio.

*   **Cache-Aside a Demanda vs. Cache-Ahead (Warm-Up):**
    *   *Decisión:* Se descartó la idea de pre-cargar (warm-up) los slots de los próximos 7 días al iniciar la aplicación.
    *   *Justificación:* Gracias a la granularidad del caché implementado (que almacena clubes y canchas de manera independiente de la fecha), pre-cargar los 7 días requeriría **120 llamadas HTTP** en total ($24 \text{ req}$ el primer día para inicializar metadatos y slots, más $16 \text{ req}$ de slots por cada uno de los 6 días restantes). Sin embargo, debido al límite estricto de la API Mock de **60 solicitudes por minuto**, este proceso de warm-up al arrancar saturaría la cuota del proveedor externo durante al menos **2 minutos enteros**, provocando que cualquier solicitud de búsqueda entrante sea respondida con ninguna disponibilidad debido a que no hay cuota para consultar a la API Mock. Se prefirió una estrategia *Cache-Aside* a demanda para proteger la cuota operativa. Esto no quiere decir que no se pueda implementar, simplemente es una cuestión de decisión, el negocio podría decidir sacrificar esos primeros minutos de operación del servidor haciendo esta operación de Warm-Up en un horario poco concurrido como ser de madrugada, entonces inicialmente se hace un proceso largo para cachear los 7 días, y cada madrugada un proceso para cachear el nuevo día entrante (día actual + 7). Por una cuestión de simplicidad, de arrancar el proyecto y comprobar el funcionamiento de este sin esperar varios minutos a que el cache en warm se complete se optó por el Cache-Aside, haciendo pagar el tiempo en frío de ~4.5 segundos a la primera petición de una zona y día.

*   **Mutación Directa en RAM vs. Estrategia Refresh-Ahead (Re-consulta por Red):**
    *   *Decisión:* Ante eventos de reserva (`booking_created`) y cancelación (`booking_cancelled`), la caché se modifica quirúrgicamente en memoria RAM de manera síncrona (`O(1)`) en lugar de disparar una consulta HTTP en segundo plano a la API Mock para refrescar el estado.
    *   *Justificación:* El payload de los webhooks provisto por la API Mock es "rico" (contiene el slot completo, fecha, hora e IDs). Hacer una petición HTTP de refresco externa para validar el estado iría en contra de la resiliencia del sistema: saturaría el Rate Limit ante ráfagas de reservas e introduciría riesgos de **condiciones de carrera** (Race Conditions), donde una respuesta de red lenta de un evento anterior podría sobrescribir y corromper el estado de una actualización más reciente. La mutación local en RAM garantiza consistencia secuencial determinística inmediata con 0 llamadas de red.

---

## Posibles Evoluciones para Producción
Aunque las decisiones tomadas fueron optimizadas para la escala actual y el entorno provisto, se consideraron y diseñaron los siguientes caminos de evolución para un entorno distribuido en producción:
1. **Migración Transparente a Redis (Multi-Instance Clustering):**
   * *Escenario:* Al escalar horizontalmente a múltiples réplicas/pods (ej. Kubernetes o ECS) detrás de un Load Balancer, cada nodo con RAM propia sufriría desincronización de caché.
   * *Solución:* Gracias al patrón Hexagonal implementado (`AvailabilityCache` port), basta con crear un nuevo adaptador `RedisAvailabilityCache` reemplazando el provider en NestJS (`app.module.ts`), logrando un caché distribuido centralizado sin modificar una sola línea de lógica de dominio.
2. **Circuit Breaker Pattern (Cockatiel / Opossum):**
   * *Escenario:* Caídas masivas o degradaciones prolongadas del proveedor externo.
   * *Solución:* Implementar un *Circuit Breaker* que abra el circuito tras 5 fallos consecutivos de la Mock API, respondiendo inmediatamente en 0ms con respuestas degradadas o fallback en stale-data sin intentar aperturas de sockets ni esperar timeouts de 10s.
3. **Self-Healing Soft TTL & Idempotencia de Webhooks:**
   * *Escenario:* Pérdida eventual de webhooks por caídas de red o reinicios de pods.
   * *Solución:* Añadir una marca temporal (`cachedAt`) a cada entrada para un refresco bajo demanda (*Self-Healing Soft TTL*) tras 5-10 minutos de inactividad, junto con un registro de idempotencia (`event_id`) para evitar procesar webhooks duplicados.
4. **Observabilidad y Métricas (Prometheus + Grafana):**
   * *Escenario:* Monitoreo operativo en tiempo real.
   * *Solución:* Instrumentación de métricas para supervisar la tasa de efectividad de la memoria (*Cache Hit Ratio* vs. *Cache Miss Ratio*), latencia P95/P99, y la cantidad de peticiones deduplicadas en vuelo por el patrón Single-Flight.
---

## Pruebas Unitarias
Se ejecutó la suite de tests unitarios verificando la solución (`12 passed`):
* `in-memory-availability.cache.spec.ts`: Testea evicción de 7 días, persistencia e invalidaciones.
* `http-alquila-tu-cancha.client.spec.ts`: Valida que el patrón Single-Flight reduzca ráfagas concurrentes a una única llamada de red real.
* `get-availability.handler.spec.ts`: Comprueba la paralelización con `Promise.all` y la tolerancia a fallos cuando la API externa no está disponible.

---

## Referencias Consultadas
* [NestJS CQRS Module Documentation](https://docs.nestjs.com/recipes/cqrs)
* [NestJS Axios (HttpModule)](https://docs.nestjs.com/techniques/http-module)
* [Single-Flight Pattern (Go Reference)](https://pkg.go.dev/golang.org/x/sync/singleflight)
* [Redis Caching Strategies & Local Memory Trade-offs](https://redis.io/docs/latest/develop/use/caching/)
